### PR TITLE
Enable html error messages

### DIFF
--- a/R/dtedit.R
+++ b/R/dtedit.R
@@ -688,7 +688,7 @@ dteditmod <- function(input, output, session,
     return(fields)
   }
 
-  output[[paste0(name, "_message")]] <- shiny::renderText("")
+  output[[paste0(name, "_message")]] <- shiny::renderUI("")
 
   updateData <- function(proxy, data, ...) {
     # updates data displayed in DT datatable
@@ -729,12 +729,12 @@ dteditmod <- function(input, output, session,
     #
     # other than being closed/cancelled
     # the 'addModal' popup can create an '_insert' event
-    output[[paste0(name, "_message")]] <- shiny::renderText("")
+    output[[paste0(name, "_message")]] <- shiny::renderUI("")
     fields <- getFields("_add_", values)
     shiny::modalDialog(
       title = title.add,
       shiny::div(
-        shiny::textOutput(
+        shiny::htmlOutput(
           ns(paste0(name, "_message"))
         ),
         style = "color:red"
@@ -822,7 +822,7 @@ dteditmod <- function(input, output, session,
       shiny::removeModal()
       return(TRUE)
     }, error = function(e) {
-      output[[paste0(name, "_message")]] <<- shiny::renderText(geterrmessage())
+      output[[paste0(name, "_message")]] <<- shiny::renderUI(HTML(geterrmessage()))
       return(FALSE)
     })
   })
@@ -856,7 +856,7 @@ dteditmod <- function(input, output, session,
     #
     # other than being closed/cancelled, the 'editModal' popup
     # can also be closed when the '_update' event is observed
-    output[[paste0(name, "_message")]] <- renderText("")
+    output[[paste0(name, "_message")]] <- renderUI("")
     fields <- getFields("_edit_", values = result$thedata[row, , drop = FALSE])
     shiny::modalDialog(
       title = title.edit,
@@ -866,7 +866,7 @@ dteditmod <- function(input, output, session,
             shiny::h4(rownames(thedata)[row])
         ),
         shiny::div(
-          shiny::textOutput(
+          shiny::htmlOutput(
             ns(paste0(name, "_message"))),
           style = "color:red"),
         fields
@@ -940,7 +940,7 @@ dteditmod <- function(input, output, session,
         shiny::removeModal()
         return(TRUE)
       }, error = function(e) {
-        output[[paste0(name, "_message")]] <<- shiny::renderText(geterrmessage())
+        output[[paste0(name, "_message")]] <<- shiny::renderUI(HTML(geterrmessage()))
         return(FALSE)
       })
     }
@@ -969,7 +969,7 @@ dteditmod <- function(input, output, session,
       fields[[i]] <- div(paste0(delete.info.label.cols[i], " = ",
                                 result$thedata[row, delete.info.cols[i]]))
     }
-    output[[paste0(name, "_message")]] <- shiny::renderText("")
+    output[[paste0(name, "_message")]] <- shiny::renderUI("")
     shiny::modalDialog(
       title = title.delete,
       shiny::fluidPage(
@@ -978,7 +978,7 @@ dteditmod <- function(input, output, session,
             shiny::h4(rownames(thedata)[row])
         ),
         shiny::div(
-          shiny::textOutput(
+          shiny::htmlOutput(
             ns(paste0(name, "_message"))), style = "color:red"
         ),
         shiny::p(text.delete.modal),
@@ -1020,7 +1020,7 @@ dteditmod <- function(input, output, session,
         return(TRUE)
       },
       error = function(e) {
-        output[[paste0(name, "_message")]] <<- shiny::renderText(geterrmessage())
+        output[[paste0(name, "_message")]] <<- shiny::renderUI(HTML(geterrmessage()))
         return(FALSE)
       }
       )
@@ -1066,7 +1066,7 @@ dteditmod <- function(input, output, session,
       return(TRUE)
     },
     error = function(e) {
-      output[[paste0(name, "_message")]] <<- shiny::renderText(geterrmessage())
+      output[[paste0(name, "_message")]] <<- shiny::renderUI(HTML(geterrmessage()))
       return(FALSE)
     }
     )


### PR DESCRIPTION
A simple use case is to put html line breaks between validation error messages:

```r
grocery.insert.callback <- function(data, row) {
  # 'data' contains the dataframe *after* the row has been inserted

  msg <- list()
  if (data[row, "Buy"] == "") {
    msg[[1]] <- "Item name can't be empty!"
  }
  if (data[row, "Quantity"] > 10) {
    msg[[2]] <- "Can't buy more than ten (10)!"
  }
  msg <- Filter(Negate(is.null), msg)
  if (length(msg)) stop(paste(msg, collapse = "<br>"))

  return(data)
}
```
