### PR TITLE
FIX ERROR if checkboxInput value == NA: missing value where TRUE/FALSE needed

### DIFF
--- a/R/dtedit.R
+++ b/R/dtedit.R
@@ -900,6 +900,7 @@ dteditmod <- function(input, output, session,
         )
       } else if (inputTypes[i] == "checkboxInput") {
         value <- ifelse(missing(values), FALSE, values[, edit.cols[i]])
+        value <- ifelse(is.na(value), FALSE, value)
         fields[[i]] <- shiny::checkboxInput(
           ns(paste0(name, typeName, edit.cols[i])),
           label = edit.label.cols[i],


### PR DESCRIPTION
Apparently `shiny::checkboxInput()` cannot handle a value of NA, so this single line updates the value to FALSE so the app doesn't crash.